### PR TITLE
Adding raise when encountering RequestException

### DIFF
--- a/habanero/request.py
+++ b/habanero/request.py
@@ -41,6 +41,7 @@ def request(url, path, ids = None, query = None, filter = None,
         r.raise_for_status()
     except requests.exceptions.RequestException as e:
       print(e)
+      raise
     check_json(r)
     coll = r.json()
     # coll = switch_classes(js, path, works)
@@ -74,6 +75,7 @@ def request(url, path, ids = None, query = None, filter = None,
             r.raise_for_status()
         except requests.exceptions.RequestException as e:
           print(e)
+          raise
         check_json(r)
         js = r.json()
         #tt_out = switch_classes(js, path, works)


### PR DESCRIPTION
In two locations in `request()`, when encountering `except requests.exceptions.RequestException` the exception message would just be printed (leading to a possible error, e.g., with `check_json(r)` because `r` is not assigned). This change `raise`s these exceptions.