### PR TITLE
Use HTTPS for default Crossref API URL

### DIFF
--- a/habanero/crossref/crossref.py
+++ b/habanero/crossref/crossref.py
@@ -44,7 +44,7 @@ class Crossref(object):
         Crossref(api_key = "123456")
 
     '''
-    def __init__(self, base_url = "http://api.crossref.org", api_key = None):
+    def __init__(self, base_url = "https://api.crossref.org", api_key = None):
 
         self.base_url = base_url
         self.api_key = api_key


### PR DESCRIPTION
Be secure.