### PR TITLE
Fix python 2 compatibility when submitting unicode DOI

### DIFF
--- a/habanero/cnrequest.py
+++ b/habanero/cnrequest.py
@@ -7,8 +7,18 @@ from .cn_formats import *
 def CNRequest(url, ids = None, format = None, style = None,
         locale = None, **kwargs):
 
-  if(ids.__class__.__name__ == "str"):
+  should_split = False
+  try:
+    # Python 2
+    if isinstance(ids, (str, unicode)):
+      should_split = True
+  except NameError:
+    # Python 3
+    if isinstance(ids, str):
+      should_split = True
+  if should_split:
     ids = ids.split()
+
   if(ids.__class__.__name__ == "int"):
     ids = [ids]
 

--- a/habanero/cnrequest.py
+++ b/habanero/cnrequest.py
@@ -19,7 +19,7 @@ def CNRequest(url, ids = None, format = None, style = None,
   if should_split:
     ids = ids.split()
 
-  if(ids.__class__.__name__ == "int"):
+  if isinstance(ids, int):
     ids = [ids]
 
   if(len(ids) == 1):

--- a/test/test-content_negotation.py
+++ b/test/test-content_negotation.py
@@ -9,8 +9,13 @@ bibtex = '@article{Frank_1970,\n\tdoi = {10.1126/science.169.3946.635},\n\turl =
 cjson = '{"indexed":{"date-parts":[[2015,9,18]],"date-time":"2015-09-18T16:11:22Z","timestamp":1442592682239},"reference-count":0,"publisher":"American Association for the Advancement of Science (AAAS)","issue":"3946","DOI":"10.1126\\/science.169.3946.635","type":"journal-article","created":{"date-parts":[[2006,10,5]],"date-time":"2006-10-05T12:56:56Z","timestamp":1160053016000},"page":"635-641","source":"CrossRef","title":"The Structure of Ordinary Water: New data and interpretations are yielding new insights into this fascinating substance","prefix":"http:\\/\\/id.crossref.org\\/prefix\\/10.1126","volume":"169","author":[{"affiliation":[],"family":"Frank","given":"H. S."}],"member":"http:\\/\\/id.crossref.org\\/member\\/221","container-title":"Science","deposited":{"date-parts":[[2011,6,27]],"date-time":"2011-06-27T21:18:25Z","timestamp":1309209505000},"score":1.0,"subtitle":[],"issued":{"date-parts":[[1970,8,14]]},"URL":"http:\\/\\/dx.doi.org\\/10.1126\\/science.169.3946.635","ISSN":["0036-8075","1095-9203"]}'
 
 def test_content_negotiation():
-    "content negotiation - deafult - bibtex"
+    "content negotiation - default - bibtex"
     res = cn.content_negotiation(ids = '10.1126/science.169.3946.635')
+    assert str == str(res).__class__
+
+def test_content_negotiation_with_unicode_doi():
+    "content negotiation - unicode"
+    res = cn.content_negotiation(ids = u'10.1126/science.169.3946.635')
     assert str == str(res).__class__
 
 def test_content_negotiation_citeproc_json():


### PR DESCRIPTION
## Purpose

Submitting a unicode string as a DOI for content negotiation fails on python 2.

## Proposal

Fix type detection in content negotiation to split unicode litteral (if any). 

See [this line](https://github.com/sckott/habanero/blob/master/habanero/cnrequest.py#L10).

Remark: we expect the new test to fail with python 2