### PR TITLE
Make tests independent of optdeps

### DIFF
--- a/test/test-content_negotation.py
+++ b/test/test-content_negotation.py
@@ -17,9 +17,26 @@ def test_content_negotiation():
     assert isinstance(res, str)
 
 
+def pkgverBounds(pkg, minVer, maxVer=None):
+    from importlib.util import find_spec
+    from importlib.metadata import version
+    from packaging.version import Version
+
+    # Package not installed
+    if(not find_spec(pkg)):
+        return False
+
+    ver = Version(version(pkg))
+
+    return Version(minVer) <= ver and (maxVer is None or ver < Version(maxVer))
+
+
 # addresses https://github.com/sckott/habanero/issues/144
 # this DOI gives back the month as "sep" instead of "{sep}" as it should
 @pytest.mark.vcr
+@pytest.mark.skipif(
+        not pkgverBounds("bibtexparser", "2.0.0b5"),
+        reason='Test requires the optional dependency "bibtexparser" to run')
 def test_content_negotiation_bad_bibtex():
     """content negotiation - bad bibtex is fixed correctly"""
     month_regex = re.compile(r"\{sep\}")


### PR DESCRIPTION
## Description

`test_content_negotiation_bad_bibtex` as currently written will always run, even
if the optional dependency `bibtexparser` is not installed.

For people using the testsuite to validate their installs who aren't installing
`bibtexparser`, that makes this unnecessarily annoying (one needs to pass `-k
'not test_...'` to achieve the same effect).

Instead, this PR makes the test conditional on `bibtexparser` being installed.

## Related Issue

Fixes: #144
