### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,6 +2,9 @@ name: Python
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sckott/habanero/security/code-scanning/4](https://github.com/sckott/habanero/security/code-scanning/4)

In general, this problem is fixed by adding an explicit `permissions` block to the workflow (at the top level or per job) to restrict the `GITHUB_TOKEN` to the least privileges required. For a typical Python CI workflow that only checks out code and runs tests, `contents: read` is usually sufficient; additional scopes (e.g., `pull-requests: write`) should only be added if a step needs them.

For this specific workflow in `.github/workflows/python.yml`, the best fix without changing functionality is to add a top-level `permissions` block just under the `name:` (or above `jobs:`) that sets `contents: read`. None of the existing steps need to push code, create releases, or modify issues/PRs; Codecov uses its own `CODECOV_TOKEN`. Therefore `contents: read` suffices and documents the intended permissions. No new imports or methods are needed—this is a pure YAML configuration change. Concretely, add:

```yaml
permissions:
  contents: read
```

between the `on:` section and the `jobs:` section (or right after `name:`), keeping indentation consistent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
