### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint w/ ruff
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sckott/habanero/security/code-scanning/2](https://github.com/sckott/habanero/security/code-scanning/2)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required access to the `GITHUB_TOKEN`. For a lint job that just checks code and posts annotations via the GitHub Actions log, `contents: read` is sufficient and is the recommended minimal starting point. This can be set at the workflow root (to apply to all jobs) or at the job level (for finer control).

The best fix here without changing functionality is to add a workflow-level `permissions:` block just after the `on:` section, specifying `contents: read`. This ensures the `ruff` job runs with a token that can read the repository contents but cannot write to the repository or other resources. No changes are needed to the existing steps, and no additional imports or actions are required.

Concretely, in `.github/workflows/lint.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on: [push, pull_request]` line and the `jobs:` line. No other files or regions need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
