### PR TITLE
Rename builtin-shadowing arguments

### DIFF
--- a/docs/modules/cn.rst
+++ b/docs/modules/cn.rst
@@ -14,11 +14,11 @@ Example usage:
 
     from habanero import cn
     cn.content_negotiation(ids = '10.1126/science.169.3946.635')
-    cn.content_negotiation(ids = '10.1126/science.169.3946.635', format = "citeproc-json")
-    cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "rdf-xml")
-    cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "crossref-xml")
-    cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "text")
-    cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "bibentry")
+    cn.content_negotiation(ids = '10.1126/science.169.3946.635', citation_format = "citeproc-json")
+    cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "rdf-xml")
+    cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "crossref-xml")
+    cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "text")
+    cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "bibentry")
 
 
 

--- a/habanero/cn/cn.py
+++ b/habanero/cn/cn.py
@@ -4,7 +4,7 @@ from .constants import CN_BASE_URL
 
 def content_negotiation(
     ids: str,
-    format: str = "bibtex", # noqa: A002
+    citation_format: str = "bibtex",
     style: str = "apa",
     locale: str = "en-US",
     url: str = "",
@@ -17,7 +17,7 @@ def content_negotiation(
 
     :param ids: required. a single DOI or many DOIs, each a string. If many
         passed in, do so in a list
-    :param format: Name of the format. One of "rdf-xml", "turtle", "citeproc-json",
+    :param citation_format: Name of the format. One of "rdf-xml", "turtle", "citeproc-json",
         "citeproc-json-ish", "text", "ris", "bibtex" (Default), "crossref-xml",
         "datacite-xml","bibentry", or "crossref-tdm"
     :param style: A CSL style (for text format only). See :func:`~habanero.cn.csl_styles`
@@ -47,35 +47,35 @@ def content_negotiation(
         cn.content_negotiation(ids = "10.1400/22888")
 
         # get citeproc-json
-        cn.content_negotiation(ids = '10.1126/science.169.3946.635', format = "citeproc-json")
+        cn.content_negotiation(ids = '10.1126/science.169.3946.635', citation_format = "citeproc-json")
 
         # some other formats
-        cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "rdf-xml")
-        cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "crossref-xml")
-        cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "text")
+        cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "rdf-xml")
+        cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "crossref-xml")
+        cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "text")
 
         # return an R bibentry type
-        cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "bibentry")
+        cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "bibentry")
 
         # return an apa style citation
-        cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "text", style = "apa")
-        cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "text", style = "elsevier-harvard")
-        cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "text", style = "ecoscience")
-        cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "text", style = "heredity")
-        cn.content_negotiation(ids = "10.1126/science.169.3946.635", format = "text", style = "oikos")
+        cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "text", style = "apa")
+        cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "text", style = "elsevier-harvard")
+        cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "text", style = "ecoscience")
+        cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "text", style = "heredity")
+        cn.content_negotiation(ids = "10.1126/science.169.3946.635", citation_format = "text", style = "oikos")
 
         # Using DataCite DOIs
         ## some formats don't work
-        # cn.content_negotiation(ids = "10.15468/t4rau8", format = "crossref-xml")
+        # cn.content_negotiation(ids = "10.15468/t4rau8", citation_format = "crossref-xml")
 
         ## But most do work
-        cn.content_negotiation(ids = "10.15468/t4rau8", format = "crossref-tdm")
-        cn.content_negotiation(ids = "10.15468/t4rau8", format = "datacite-xml")
-        cn.content_negotiation(ids = "10.15468/t4rau8", format = "turtle")
-        cn.content_negotiation(ids = "10.15468/t4rau8", format = "ris")
-        cn.content_negotiation(ids = "10.15468/t4rau8", format = "bibtex")
-        cn.content_negotiation(ids = "10.15468/t4rau8", format = "bibentry")
-        cn.content_negotiation(ids = "10.15468/t4rau8", format = "bibtex")
+        cn.content_negotiation(ids = "10.15468/t4rau8", citation_format = "crossref-tdm")
+        cn.content_negotiation(ids = "10.15468/t4rau8", citation_format = "datacite-xml")
+        cn.content_negotiation(ids = "10.15468/t4rau8", citation_format = "turtle")
+        cn.content_negotiation(ids = "10.15468/t4rau8", citation_format = "ris")
+        cn.content_negotiation(ids = "10.15468/t4rau8", citation_format = "bibtex")
+        cn.content_negotiation(ids = "10.15468/t4rau8", citation_format = "bibentry")
+        cn.content_negotiation(ids = "10.15468/t4rau8", citation_format = "bibtex")
 
         # many DOIs
         dois = ['10.5167/UZH-30455','10.5167/UZH-49216','10.5167/UZH-503', '10.5167/UZH-38402','10.5167/UZH-41217']
@@ -88,4 +88,4 @@ def content_negotiation(
     if not url:
         url = CN_BASE_URL
 
-    return CNRequest(url, ids, format, style, locale, **kwargs)
+    return CNRequest(url, ids, citation_format, style, locale, **kwargs)

--- a/habanero/cnrequest.py
+++ b/habanero/cnrequest.py
@@ -14,7 +14,7 @@ else:
     _has_bibtexparser = True
 
 
-def CNRequest(url, ids, format=None, style=None, locale=None, **kwargs):  # noqa: A002 (format)
+def CNRequest(url, ids, citation_format=None, style=None, locale=None, **kwargs):
     if not isinstance(ids, (str, list)):
         raise TypeError("'ids' must be a str or list of str's")
     if isinstance(ids, list) and not all(isinstance(z, str) for z in ids):
@@ -25,11 +25,15 @@ def CNRequest(url, ids, format=None, style=None, locale=None, **kwargs):  # noqa
         ids = ids.split()
 
     if len(ids) == 1:
-        return make_request(url, ids[0], format, style, locale, fail=True, **kwargs)
+        return make_request(
+            url, ids[0], citation_format, style, locale, fail=True, **kwargs
+        )
     else:
         coll = []
         for i in range(len(ids)):
-            tt = make_request(url, ids[i], format, style, locale, fail=False, **kwargs)
+            tt = make_request(
+                url, ids[i], citation_format, style, locale, fail=False, **kwargs
+            )
             coll.append(tt)
 
         if len(coll) == 1:

--- a/habanero/crossref/crossref.py
+++ b/habanero/crossref/crossref.py
@@ -216,7 +216,7 @@ class Crossref:
         self,
         ids: List[str] | str | None = None,
         query: Optional[str] = None,
-        filter: Optional[dict] = None, # noqa: A002 (TODO: fix at next major version)
+        filters: Optional[dict] = None,
         offset: Optional[float] = None,
         limit: Optional[float] = None,
         sample: Optional[float] = None,
@@ -235,7 +235,7 @@ class Crossref:
 
         :param ids: DOIs (digital object identifier) or other identifiers
         :param query: A query string
-        :param filter: Filter options. See examples for usage.
+        :param filters: Filter options. See examples for usage.
             Accepts a dict, with filter names and their values. For repeating filter names
             pass in a list of the values to that filter name, e.g.,
             `{'award_funder': ['10.13039/100004440', '10.13039/100000861']}`.
@@ -296,11 +296,11 @@ class Crossref:
             x['message']['items']
 
             # Get full text links
-            x = cr.works(filter = {'has_full_text': True})
+            x = cr.works(filters = {'has_full_text': True})
             x
 
             # Parse output to various data pieces
-            x = cr.works(filter = {'has_full_text': True})
+            x = cr.works(filters = {'has_full_text': True})
             ## get doi for each item
             [ z['DOI'] for z in x['message']['items'] ]
             ## get doi and url for each item
@@ -311,11 +311,11 @@ class Crossref:
 
             # filters - pass in as a dict
             ## see https://github.com/CrossRef/rest-api-doc#filter-names
-            cr.works(filter = {'has_full_text': True})
-            cr.works(filter = {'has_funder': True, 'has_full_text': True})
-            cr.works(filter = {'award_number': 'CBET-0756451', 'award_funder': '10.13039/100000001'})
+            cr.works(filters = {'has_full_text': True})
+            cr.works(filters = {'has_funder': True, 'has_full_text': True})
+            cr.works(filters = {'award_number': 'CBET-0756451', 'award_funder': '10.13039/100000001'})
             ## to repeat a filter name, pass in a list
-            x = cr.works(filter = {'award_funder': ['10.13039/100004440', '10.13039/100000861']}, limit = 100)
+            x = cr.works(filters = {'award_funder': ['10.13039/100004440', '10.13039/100000861']}, limit = 100)
             map(lambda z:z['funder'][0]['DOI'], x['message']['items'])
 
             # Deep paging, using the cursor parameter
@@ -367,7 +367,7 @@ class Crossref:
                 "/works/",
                 ids,
                 query,
-                filter,
+                filters,
                 offset,
                 limit,
                 sample,
@@ -391,7 +391,7 @@ class Crossref:
                 self.base_url,
                 "/works/",
                 query,
-                filter,
+                filters,
                 offset,
                 limit,
                 sample,
@@ -410,7 +410,7 @@ class Crossref:
         self,
         ids: List[str] | str | int | None = None,
         query: Optional[str] = None,
-        filter: Optional[dict] = None, # noqa: A002 (TODO: fix at next major version)
+        filters: Optional[dict] = None,
         offset: Optional[float] = None,
         limit: Optional[float] = None,
         sample: Optional[float] = None,
@@ -430,7 +430,7 @@ class Crossref:
 
         :param ids: DOIs (digital object identifier) or other identifiers
         :param query: A query string
-        :param filter: Filter options. See examples for usage.
+        :param filters: Filter options. See examples for usage.
             Accepts a dict, with filter names and their values. For repeating filter names
             pass in a list of the values to that filter name, e.g.,
             `{'award_funder': ['10.13039/100004440', '10.13039/100000861']}`.
@@ -498,14 +498,14 @@ class Crossref:
             [ x['author'][0]['family'] for x in res['message']['items'] ]
 
             # filters (as of this writing, 4 filters are avail., see filter_names())
-            res = cr.members(filter = {'has_public_references': True})
+            res = cr.members(filters = {'has_public_references': True})
         """
         return request(
             self,
             "/members/",
             ids,
             query,
-            filter,
+            filters,
             offset,
             limit,
             sample,
@@ -525,7 +525,7 @@ class Crossref:
     def prefixes(
         self,
         ids: List[str] | str,
-        filter: Optional[dict] = None, # noqa: A002 (TODO: fix at next major version)
+        filters: Optional[dict] = None,
         offset: Optional[float] = None,
         limit: Optional[float] = None,
         sample: Optional[float] = None,
@@ -544,7 +544,7 @@ class Crossref:
         Search Crossref prefixes
 
         :param ids: DOIs (digital object identifier) or other identifiers. required
-        :param filter: Filter options. See examples for usage.
+        :param filters: Filter options. See examples for usage.
             Accepts a dict, with filter names and their values. For repeating filter names
             pass in a list of the values to that filter name, e.g.,
             `{'award_funder': ['10.13039/100004440', '10.13039/100000861']}`.
@@ -611,7 +611,7 @@ class Crossref:
             res = cr.prefixes(ids = "10.1016", works = True, cursor = "*", cursor_max = 200, progress_bar = True)
 
             # field queries
-            res = cr.prefixes(ids = "10.1371", works = True, query_editor = 'cooper', filter = {'type': 'journal-article'})
+            res = cr.prefixes(ids = "10.1371", works = True, query_editor = 'cooper', filters = {'type': 'journal-article'})
             eds = [ x.get('editor') for x in res['message']['items'] ]
             [ z for z in eds if z is not None ]
         """
@@ -621,7 +621,7 @@ class Crossref:
             "/prefixes/",
             ids,
             query=None,
-            filter=filter,
+            filters=filters,
             offset=offset,
             limit=limit,
             sample=sample,
@@ -641,7 +641,7 @@ class Crossref:
         self,
         ids: List[str] | str | None = None,
         query: Optional[str] = None,
-        filter: Optional[dict] = None, # noqa: A002 (TODO: fix at next major version)
+        filters: Optional[dict] = None,
         offset: Optional[float] = None,
         limit: Optional[float] = None,
         sample: Optional[float] = None,
@@ -664,7 +664,7 @@ class Crossref:
 
         :param ids: DOIs (digital object identifier) or other identifiers
         :param query: A query string
-        :param filter: Filter options. See examples for usage.
+        :param filters: Filter options. See examples for usage.
             Accepts a dict, with filter names and their values. For repeating filter names
             pass in a list of the values to that filter name, e.g.,
             `{'award_funder': ['10.13039/100004440', '10.13039/100000861']}`.
@@ -727,12 +727,12 @@ class Crossref:
             res = cr.funders(ids = '10.13039/100000001', works = True, cursor = "*", cursor_max = 200, progress_bar = True)
 
             # field queries
-            res = cr.funders(ids = "10.13039/100000001", works = True, query_container_title = 'engineering', filter = {'type': 'journal-article'})
+            res = cr.funders(ids = "10.13039/100000001", works = True, query_container_title = 'engineering', filters = {'type': 'journal-article'})
             eds = [ x.get('editor') for x in res['message']['items'] ]
             [ z for z in eds if z is not None ]
 
             # filters (as of this writing, only 1 filter is avail., "location")
-            cr.funders(filter = {'location': "Sweden"})
+            cr.funders(filters = {'location': "Sweden"})
 
             # warn
             cr.funders(ids = '10.13039/notarealdoi')
@@ -748,7 +748,7 @@ class Crossref:
             "/funders/",
             ids,
             query,
-            filter,
+            filters,
             offset,
             limit,
             sample,
@@ -769,7 +769,7 @@ class Crossref:
         self,
         ids: List[str] | str | None = None,
         query: Optional[str] = None,
-        filter: Optional[dict] = None, # noqa: A002 (TODO: fix at next major version)
+        filters: Optional[dict] = None,
         offset: Optional[float] = None,
         limit: Optional[float] = None,
         sample: Optional[float] = None,
@@ -789,7 +789,7 @@ class Crossref:
 
         :param ids: DOIs (digital object identifier) or other identifiers
         :param query: A query string
-        :param filter: Filter options. See examples for usage.
+        :param filters: Filter options. See examples for usage.
             Accepts a dict, with filter names and their values. For repeating filter names
             pass in a list of the values to that filter name, e.g.,
             `{'award_funder': ['10.13039/100004440', '10.13039/100000861']}`.
@@ -848,7 +848,7 @@ class Crossref:
             cr.journals(ids = "2167-8359", works = True)
             cr.journals(ids = "2167-8359", query = 'ecology', works = True, sort = 'score', order = "asc")
             cr.journals(ids = "2167-8359", query = 'ecology', works = True, sort = 'score', order = "desc")
-            cr.journals(ids = "2167-8359", works = True, filter = {'from_pub_date': '2014-03-03'})
+            cr.journals(ids = "2167-8359", works = True, filters = {'from_pub_date': '2014-03-03'})
             cr.journals(ids = '1803-2427', works = True)
             cr.journals(ids = '1803-2427', works = True, sample = 1)
             cr.journals(limit: 2)
@@ -863,7 +863,7 @@ class Crossref:
             res = cr.journals(ids = "2167-8359", works = True, cursor = "*", cursor_max = 200, progress_bar = True)
 
             # field queries
-            res = cr.journals(ids = "2167-8359", works = True, query_bibliographic = 'fish', filter = {'type': 'journal-article'})
+            res = cr.journals(ids = "2167-8359", works = True, query_bibliographic = 'fish', filters = {'type': 'journal-article'})
             [ x.get('title') for x in res['message']['items'] ]
         """
         return request(
@@ -871,7 +871,7 @@ class Crossref:
             "/journals/",
             ids,
             query,
-            filter,
+            filters,
             offset,
             limit,
             sample,
@@ -892,7 +892,7 @@ class Crossref:
         self,
         ids: List[str] | str | None = None,
         query: Optional[str] = None,
-        filter: Optional[dict] = None, # noqa: A002 (TODO: fix at next major version)
+        filters: Optional[dict] = None,
         offset: Optional[float] = None,
         limit: Optional[float] = None,
         sample: Optional[float] = None,
@@ -912,7 +912,7 @@ class Crossref:
 
         :param ids: Type identifier, e.g., journal
         :param query: A query string
-        :param filter: Filter options. See examples for usage.
+        :param filters: Filter options. See examples for usage.
             Accepts a dict, with filter names and their values. For repeating filter names
             pass in a list of the values to that filter name, e.g.,
             `{'award_funder': ['10.13039/100004440', '10.13039/100000861']}`.
@@ -973,7 +973,7 @@ class Crossref:
             "/types/",
             ids,
             query,
-            filter,
+            filters,
             offset,
             limit,
             sample,
@@ -1140,7 +1140,7 @@ class Crossref:
         )
         return [z["DOI"] for z in res["message"]["items"]]
 
-    def filter_names(self, type: str = "works") -> list: # noqa: A002 (TODO: fix at next major version)
+    def filter_names(self, route: str = "works") -> list:
         """
         Filter names - just the names of each filter
 
@@ -1148,7 +1148,7 @@ class Crossref:
         As filters are introduced or taken away, we may get out of sync; check
         the docs for the latest https://github.com/CrossRef/rest-api-doc
 
-        :param type: what type of filters, i.e., what API route, matches
+        :param route: what type of filters, i.e., what API route, matches
             methods here. one of "works", "members", or "funders". Default: "works"
         :rtype: list
 
@@ -1160,11 +1160,11 @@ class Crossref:
             cr.filter_names("members")
             cr.filter_names("funders")
         """
-        nms = list(self.filter_details(type).keys())
+        nms = list(self.filter_details(route).keys())
         nms.sort()
         return nms
 
-    def filter_details(self, type: str = "works") -> dict: # noqa: A002 (TODO: fix at next major version)
+    def filter_details(self, route: str = "works") -> dict:
         """
         Filter details - filter names, possible values, and description
 
@@ -1172,7 +1172,7 @@ class Crossref:
         As filters are introduced or taken away, we may get out of sync; check
         the docs for the latest https://github.com/CrossRef/rest-api-doc
 
-        :param type: what type of filters, i.e., what API route,
+        :param route: what type of filters, i.e., what API route,
             matches methods here. one of "works", "members", or "funders".
             Default: "works"
         :rtype: dict
@@ -1189,11 +1189,11 @@ class Crossref:
             [ z['description'] for z in x.values() ]
         """
         types = ["works", "members", "funders"]
-        if type not in types:
-            raise ValueError("'type' must be one of " + "', '".join(types))
+        if route not in types:
+            raise ValueError("'route' must be one of " + "', '".join(types))
         output: dict[str, dict] = {
             "works": works_filter_details,
             "members": members_filter_details,
             "funders": funders_filter_details,
-        }[type]
+        }[route]
         return output

--- a/habanero/crossref/workscontainer.py
+++ b/habanero/crossref/workscontainer.py
@@ -37,12 +37,12 @@ class WorksContainer:
             x.abstract
     """
 
-    def __init__(self, input) -> None: # noqa: A002 (TODO: fix at next major version)
+    def __init__(self, data) -> None:
         super(WorksContainer, self).__init__()
-        if not input:
-            raise ValueError("input len must be > zero")
-        self.__input = input
-        self.works = self.works_handler(self.__input)
+        if not data:
+            raise ValueError("data len must be > zero")
+        self.__data = data
+        self.works = self.works_handler(self.__data)
         keys = list(self.works[0].keys())
         for key in keys:
             values = [work.get(key, None) for work in self.works]

--- a/habanero/request.py
+++ b/habanero/request.py
@@ -25,7 +25,7 @@ def request(
     path,
     ids=None,
     query=None,
-    filter=None, # noqa: A002 (Crossref API uses filter)
+    filters=None,
     offset=None,
     limit=None,
     sample=None,
@@ -48,7 +48,7 @@ def request(
     if cursor_max and not isinstance(cursor_max, int):
         raise ValueError("cursor_max must be of class int")
 
-    filt = filter_handler(filter)
+    filt = filter_handler(filters)
     if isinstance(select, list):
         select = ",".join(select)
 
@@ -123,7 +123,7 @@ def request(
                     url,
                     str(ids[i]) + "/works",
                     query,
-                    filter,
+                    filters,
                     offset,
                     limit,
                     sample,

--- a/habanero/request_class.py
+++ b/habanero/request_class.py
@@ -35,7 +35,7 @@ class Request(object):
         url,
         path,
         query=None,
-        filter=None, # noqa: A002 (Crossref API uses filter)
+        filters=None,
         offset=None,
         limit=None,
         sample=None,
@@ -55,7 +55,7 @@ class Request(object):
         self.url = url
         self.path = path
         self.query = query
-        self.filter = filter
+        self.filters = filters
         self.offset = offset
         self.limit = limit
         self.sample = sample
@@ -74,7 +74,7 @@ class Request(object):
         return tmpurl.strip("/")
 
     def do_request(self, should_warn=False):
-        filt = filter_handler(self.filter)
+        filt = filter_handler(self.filters)
         if isinstance(self.select, list):
             self.select = ",".join(self.select)
 

--- a/test/test-content_negotation.py
+++ b/test/test-content_negotation.py
@@ -58,7 +58,7 @@ def test_content_negotiation_with_unicode_doi():
 def test_content_negotiation_citeproc_json():
     """content negotiation - citeproc-json"""
     res = cn.content_negotiation(
-        ids="10.1126/science.169.3946.635", format="citeproc-json"
+        ids="10.1126/science.169.3946.635", citation_format="citeproc-json"
     )
     assert isinstance(res, str)
 
@@ -76,10 +76,10 @@ def test_content_negotiation_alt_url():
 def test_content_negotiation_style():
     """content negotiation - style"""
     res_apa = cn.content_negotiation(
-        ids="10.1126/science.169.3946.635", format="text", style="apa"
+        ids="10.1126/science.169.3946.635", citation_format="text", style="apa"
     )
     res_ieee = cn.content_negotiation(
-        ids="10.1126/science.169.3946.635", format="text", style="ieee"
+        ids="10.1126/science.169.3946.635", citation_format="text", style="ieee"
     )
     assert res_apa != res_ieee
 

--- a/test/test-filters.py
+++ b/test/test-filters.py
@@ -10,8 +10,8 @@ cr = Crossref()
 def test_filter_names():
     """filter_names"""
     res_works = cr.filter_names()
-    res_members = cr.filter_names("members")
-    res_funders = cr.filter_names("funders")
+    res_members = cr.filter_names(route="members")
+    res_funders = cr.filter_names(route="funders")
     assert isinstance(res_works, list)
     assert isinstance(res_works[0], str)
     assert isinstance(res_members, list)
@@ -32,8 +32,8 @@ def test_filter_names_errors():
 def test_filter_details():
     """filter_details"""
     res_works = cr.filter_details()
-    res_members = cr.filter_details("members")
-    res_funders = cr.filter_details("funders")
+    res_members = cr.filter_details(route="members")
+    res_funders = cr.filter_details(route="funders")
     assert isinstance(res_works, dict)
     assert isinstance(res_members, dict)
     assert isinstance(res_funders, dict)

--- a/test/test-funders.py
+++ b/test/test-funders.py
@@ -35,20 +35,20 @@ def test_funders_sample_err():
 @pytest.mark.vcr
 def test_funders_filter_fails_noidsworks():
     with pytest.raises(exceptions.RequestError):
-        cr.funders(filter={"from_pub_date": "2014-03-03"})
+        cr.funders(filters={"from_pub_date": "2014-03-03"})
 
 
 @pytest.mark.vcr
 def test_funders_filter_fails_noids():
     with pytest.raises(exceptions.RequestError):
-        cr.funders(works=True, filter={"has_assertion": True})
+        cr.funders(works=True, filters={"has_assertion": True})
 
 
 @pytest.mark.vcr
 def test_funders_filter_works():
     """funders - filter works when used with id and works=True"""
     res = cr.funders(
-        ids="10.13039/100000001", works=True, filter={"has_assertion": True}
+        ids="10.13039/100000001", works=True, filters={"has_assertion": True}
     )
     assert isinstance(res, dict)
     assert res["message"]["items-per-page"] == 20
@@ -74,7 +74,7 @@ def test_funders_field_queries():
         ids="10.13039/100000001",
         works=True,
         query_container_title="engineering",
-        filter={"type": "journal-article"},
+        filters={"type": "journal-article"},
         limit=100,
     )
     titles = [x.get("title") for x in res["message"]["items"]]

--- a/test/test-journals.py
+++ b/test/test-journals.py
@@ -55,13 +55,13 @@ def test_journals_works():
 @pytest.mark.vcr
 def test_journals_filter_fails_noidsworks():
     with pytest.raises(exceptions.RequestError):
-        cr.journals(filter={"from_pub_date": "2014-03-03"})
+        cr.journals(filters={"from_pub_date": "2014-03-03"})
 
 
 @pytest.mark.vcr
 def test_journals_filter_fails_noids():
     with pytest.raises(exceptions.RequestError):
-        cr.journals(works=True, filter={"has_assertion": True})
+        cr.journals(works=True, filters={"has_assertion": True})
 
 
 @no_type_check
@@ -84,7 +84,7 @@ def test_journals_field_queries():
         ids="2167-8359",
         works=True,
         query_bibliographic="fish",
-        filter={"type": "journal-article"},
+        filters={"type": "journal-article"},
     )
     titles = [x.get("title")[0] for x in res["message"]["items"]]
     assert isinstance(res, dict)

--- a/test/test-members.py
+++ b/test/test-members.py
@@ -35,7 +35,7 @@ def test_members_sample_err():
 @pytest.mark.vcr
 def test_members_filter():
     with pytest.raises(exceptions.RequestError):
-        cr.members(filter={"has_full_text": True})
+        cr.members(filters={"has_full_text": True})
 
 
 @pytest.mark.vcr

--- a/test/test-prefixes.py
+++ b/test/test-prefixes.py
@@ -27,9 +27,9 @@ def test_prefixes_works():
 
 @no_type_check
 def test_prefixes_filter():
-    """prefixes - param: filter"""
+    """prefixes - param: filters"""
     with pytest.raises(TypeError, match="missing 1 required positional"):
-        cr.prefixes(filter={"has_full_text": True})
+        cr.prefixes(filters={"has_full_text": True})
 
 
 @pytest.mark.vcr
@@ -39,7 +39,7 @@ def test_prefixes_field_queries():
         ids="10.1371",
         works=True,
         query_editor="cooper",
-        filter={"type": "journal-article"},
+        filters={"type": "journal-article"},
     )
     eds = [x.get("editor")[0] for x in res["message"]["items"]]
     assert isinstance(res, dict)

--- a/test/test-works.py
+++ b/test/test-works.py
@@ -70,7 +70,7 @@ def test_works_sample():
 # FIXME: this is constantly failing for unknown reason
 # def test_works_filter():
 #     """works - param: filter"""
-#     res = cr.works(filter = {'has_full_text': True}, limit = 3)
+#     res = cr.works(filters = {'has_full_text': True}, limit = 3)
 #     assert isinstance(res, dict)
 #     assert 5 == len(res['message'])
 

--- a/test/test-workscontainer.py
+++ b/test/test-workscontainer.py
@@ -9,7 +9,7 @@ cr = Crossref()
 def test_workscontainer_with_one_id():
     """WorksContainer: one DOI"""
     res = cr.works(ids="10.1371/journal.pone.0033693")
-    x = WorksContainer(res)
+    x = WorksContainer(data=res)
     assert isinstance(x, WorksContainer)
     assert isinstance(x.works, list)
     assert len(x.works) == 1


### PR DESCRIPTION
## Description

- rename builtin-shadowing parameters to `filters`, `citation_format`, `data`, and `route`
- preserve the Crossref wire payload key as `filter` and existing runtime behavior
- update documentation examples and tests for the new keyword names

## Related Issue

Refs #222.

## Testing

- `uv run ruff check habanero test`
- `uv run ruff format --check habanero test`
- `uv run pytest --record-mode=none test/` (129 passed, 1 optional test skipped)
- public and internal signature assertions
- `uv build`
- `git diff --check`
