### PR TITLE
fix(cn): unencode the DOI in citations returned by content_negotiation

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -3,6 +3,7 @@ Changelog
 
 DEVELOPMENT VERSION (xx)
 --------------------
+* `content_negotiation` now restores the requested DOI to its unencoded form in the returned citation; Crossref percent-encodes the DOI in the `url` field. (#99)
 * Renamed a number of arguments in methods/classes that were shadowing built-in names: `input` to `data` in `WorksContainer`; `type` to `route` in `filter_names` and `filter_details`; `format` to `citation_format` in `content_negotiation`; `filter` to `filters` in `Crossref` methods. (#222) (#223)
 
 2.9.2 (2026-06-17)

--- a/habanero/cnrequest.py
+++ b/habanero/cnrequest.py
@@ -1,4 +1,5 @@
 import warnings
+from urllib.parse import quote
 
 import httpx2
 from packaging.version import Version
@@ -66,12 +67,26 @@ def make_request(url, ids, for_mat, style, locale, fail, **kwargs):
             return None
 
     r.encoding = "UTF-8"
-    text = r.text
+    text = unencode_doi(r.text, ids)
     if for_mat == "bibtex" and _has_bibtexparser:
         bibtexparser_ver = Version(bibtexparser.__version__)
         if bibtexparser_ver.major >= 2:
             text = fix_bibtex(text)
     return text
+
+
+def unencode_doi(x, doi):
+    """Restore the DOI in a citation to its unencoded form.
+
+    Crossref percent-encodes the DOI in the ``url`` field of the citations it
+    returns (e.g. ``10.1021%2Facs.jpcc.0c05161``), which makes the URL differ
+    from the DOI itself. Only the encoded form of the requested DOI is
+    replaced, so any other percent-encoded text in the citation is left alone.
+    """
+    encoded = quote(doi, safe="")
+    if encoded == doi:
+        return x
+    return x.replace(encoded, doi)
 
 
 def fix_bibtex(x):

--- a/test/test-content_negotation.py
+++ b/test/test-content_negotation.py
@@ -1,7 +1,9 @@
 import re
 import warnings
 from typing import no_type_check
+from unittest.mock import patch
 
+import httpx2
 import pytest
 from httpx2 import HTTPError
 
@@ -82,6 +84,27 @@ def test_content_negotiation_style():
         ids="10.1126/science.169.3946.635", citation_format="text", style="ieee"
     )
     assert res_apa != res_ieee
+
+
+# addresses https://github.com/sckott/habanero/issues/99
+# Crossref percent-encodes the DOI in the returned "url" field
+def test_content_negotiation_unencodes_doi_in_citation():
+    """content negotiation - percent-encoded DOI in the url field is restored"""
+    doi = "10.1021/acs.jpcc.0c05161"
+    body = (
+        "@article{Shao_2020,\n"
+        "\tdoi = {10.1021/acs.jpcc.0c05161},\n"
+        "\turl = {https://doi.org/10.1021%2Facs.jpcc.0c05161},\n"
+        "\tyear = 2020\n}"
+    )
+    response = httpx2.Response(
+        200, text=body, request=httpx2.Request("GET", "https://doi.org/" + doi)
+    )
+    with patch("habanero.cnrequest.httpx2.get", return_value=response):
+        res = cn.content_negotiation(ids=doi)
+
+    assert "url = {https://doi.org/" + doi + "}" in res
+    assert "%2F" not in res
 
 
 # errors


### PR DESCRIPTION
## Description
Crossref percent-encodes the DOI in the `url` field of the citations returned by content negotiation, so `content_negotiation` handed back `url = {https://doi.org/10.1021%2Facs.jpcc.0c05161}` instead of the plain DOI URL. You noted the upstream ticket has sat in the Crossref backlog and suggested unquoting in habanero, so `make_request` now passes the response text through a new `unencode_doi` helper. It replaces only the percent-encoded form of the requested DOI, so any other percent-encoded text in the citation is left alone (safer than a blanket `unquote`).

## Related Issue
fix #99

## Example
```python
from habanero import cn
cn.content_negotiation(ids="10.1021/acs.jpcc.0c05161")
# before: url = {https://doi.org/10.1021%2Facs.jpcc.0c05161}
# after:  url = {https://doi.org/10.1021/acs.jpcc.0c05161}
```

Tests: added `test_content_negotiation_unencodes_doi_in_citation` in `test/test-content_negotation.py`, which mocks the Crossref response so it does not need a new cassette. It fails without the fix and passes with it; `test/test-content_negotation.py` is green (11 passed, 1 skipped) and `ruff check`/`ruff format --check` are clean.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
